### PR TITLE
fix: changed path for smartweave cli and updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lib/**/*"
   ],
   "bin": {
-    "smartweave-cli": "lib/smartweave-cli.js"
+    "smartweave-cli": "lib/bin/smartweave-cli.js"
   },
   "repository": {
     "type": "git",
@@ -31,16 +31,16 @@
   },
   "homepage": "https://github.com/ArweaveTeam/SmartWeave#readme",
   "dependencies": {
+    "@types/node": "^14.6.4",
     "arweave": "^1.9.1",
     "bignumber.js": "^9.0.0",
+    "typescript": "^4.0.2",
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "@types/node": "^14.6.3",
     "cp-cli": "^2.0.0",
     "rimraf": "^3.0.2",
     "rollup-plugin-node-polyfills": "^0.2.1",
-    "ts-node": "^8.10.2",
-    "typescript": "^3.9.5"
+    "ts-node": "^8.10.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/node@^14.6.3":
-  version "14.6.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.3.tgz#cc4f979548ca4d8e7b90bc0180052ab99ee64224"
-  integrity sha512-pC/hkcREG6YfDfui1FBmj8e20jFU5Exjw4NYDm8kEdrW+mOh0T1Zve8DWKnS7ZIZvgncrctcNCXF4Q2I+loyww==
+"@types/node@^14.6.4":
+  version "14.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
+  integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -670,10 +670,10 @@ ts-node@^8.10.2:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-typescript@^3.9.5:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
There were two errors that only came up when I tried to install smartweave with npm instead of yarn. First, typescript and all types packages should be dependencies and not devDependenices. Second, the path to smartweave-cli was incorrect.