### PR TITLE
Add Clarity contract support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -239,9 +239,9 @@
       }
     },
     "@weavery/clarity": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@weavery/clarity/-/clarity-0.1.0.tgz",
-      "integrity": "sha512-8IDDTTx6WDXGcf8yKTzPr6gsA0qQW0aIPQn7eycb4gdMHmsESHTOh/AizmBLph7WsLEQuaB5tfSeIj8kaEECrg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@weavery/clarity/-/clarity-0.1.1.tgz",
+      "integrity": "sha512-h0YEPlNqiSyBs+72BVkB1hzBp1gRL3k9L7k1T9RVGheoDvRC5NOGkuoqnvEjq4Vfuz8hpsKyT0TUpQXF1y5uhg==",
       "requires": {
         "@types/keccak": "^3.0.1",
         "keccak": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/ArweaveTeam/SmartWeave#readme",
   "dependencies": {
-    "@weavery/clarity": "^0.1.0",
+    "@weavery/clarity": "^0.1.1",
     "arweave": "^1.9.1",
     "bignumber.js": "^9.0.0",
     "loglevel": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,10 +199,10 @@
     "@typescript-eslint/types" "4.0.1"
     eslint-visitor-keys "^2.0.0"
 
-"@weavery/clarity@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@weavery/clarity/-/clarity-0.1.0.tgz#70353b708cc530d32c599a60c81dde4e079b5252"
-  integrity sha512-8IDDTTx6WDXGcf8yKTzPr6gsA0qQW0aIPQn7eycb4gdMHmsESHTOh/AizmBLph7WsLEQuaB5tfSeIj8kaEECrg==
+"@weavery/clarity@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@weavery/clarity/-/clarity-0.1.1.tgz#86a2b8777b1b00bd19d14137ddc3b6b7ed4e5e32"
+  integrity sha512-h0YEPlNqiSyBs+72BVkB1hzBp1gRL3k9L7k1T9RVGheoDvRC5NOGkuoqnvEjq4Vfuz8hpsKyT0TUpQXF1y5uhg==
   dependencies:
     "@types/keccak" "^3.0.1"
     keccak "^3.0.1"


### PR DESCRIPTION
This makes the `clarity` package namespace available to SmartWeave contracts, which is required for Clarity contracts compiled by [Sworn](https://github.com/weavery/sworn).

I also cleaned up the `createContractExecutionEnvironment` function a little bit.