### PR TITLE
Enable Clarity.js access to the SmartWeave global

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -239,9 +239,9 @@
       }
     },
     "@weavery/clarity": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@weavery/clarity/-/clarity-0.1.1.tgz",
-      "integrity": "sha512-h0YEPlNqiSyBs+72BVkB1hzBp1gRL3k9L7k1T9RVGheoDvRC5NOGkuoqnvEjq4Vfuz8hpsKyT0TUpQXF1y5uhg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@weavery/clarity/-/clarity-0.1.3.tgz",
+      "integrity": "sha512-orQLD+U4tMNSyY/6I2qAIqExcVBBC0OXXoTVn8jjfLrxCEchu+jXfk9fWHstTXxz+8K8pq7pSXMHcHidhajBvQ==",
       "requires": {
         "@types/keccak": "^3.0.1",
         "keccak": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/ArweaveTeam/SmartWeave#readme",
   "dependencies": {
-    "@weavery/clarity": "^0.1.1",
+    "@weavery/clarity": "^0.1.3",
     "arweave": "^1.9.1",
     "bignumber.js": "^9.0.0",
     "loglevel": "^1.7.0",

--- a/src/contract-load.ts
+++ b/src/contract-load.ts
@@ -58,6 +58,7 @@ export function createContractExecutionEnvironment (arweave: Arweave, contractSr
   contractSrc = contractSrc.replace(/export\s+function\s+handle/gmu, 'function handle')
   const returningSrc = `
     const [SmartWeave, BigNumber, clarity] = arguments;
+    clarity.SmartWeave = SmartWeave;
     class ContractError extends Error { constructor(message) { super(message); this.name = \'ContractError\' } };
     function ContractAssert(cond, message) { if (!cond) throw new ContractError(message) };
     ${contractSrc};

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,10 +199,10 @@
     "@typescript-eslint/types" "4.0.1"
     eslint-visitor-keys "^2.0.0"
 
-"@weavery/clarity@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@weavery/clarity/-/clarity-0.1.1.tgz#86a2b8777b1b00bd19d14137ddc3b6b7ed4e5e32"
-  integrity sha512-h0YEPlNqiSyBs+72BVkB1hzBp1gRL3k9L7k1T9RVGheoDvRC5NOGkuoqnvEjq4Vfuz8hpsKyT0TUpQXF1y5uhg==
+"@weavery/clarity@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@weavery/clarity/-/clarity-0.1.3.tgz#5d4df4722ece146b7b2083bdd0df183656b30a43"
+  integrity sha512-orQLD+U4tMNSyY/6I2qAIqExcVBBC0OXXoTVn8jjfLrxCEchu+jXfk9fWHstTXxz+8K8pq7pSXMHcHidhajBvQ==
   dependencies:
     "@types/keccak" "^3.0.1"
     keccak "^3.0.1"


### PR DESCRIPTION
This pretty much finishes the initial integration, enabling Clarity contracts to access the current block height, transaction originator, and so on.