### PR TITLE
feat: include tx parent when interacting

### DIFF
--- a/src/contract-read.ts
+++ b/src/contract-read.ts
@@ -196,6 +196,7 @@ async function getNextPage(arweave: Arweave, variables: ReqVariables) {
           }
           fee { winston }
           quantity { winston }
+          parent { id }
         }
         cursor
       }

--- a/src/interaction-tx.ts
+++ b/src/interaction-tx.ts
@@ -9,6 +9,7 @@ export interface InteractionTx {
   fee: Amount;
   quantity: Amount;
   block: Block;
+  parent: Parent;
 }
 
 interface Block {
@@ -22,4 +23,8 @@ interface Owner {
 
 interface Amount {
   winston: string;
+}
+
+interface Parent {
+  id: string;
 }

--- a/src/smartweave-global.ts
+++ b/src/smartweave-global.ts
@@ -26,7 +26,7 @@ import { readContract } from './contract-read';
 export class SmartWeaveGlobal {
   transaction: Transaction;
   block: Block;
-  arweave: Pick<Arweave, 'ar' | 'wallets' | 'utils' | 'crypto'>;
+  arweave: Pick<Arweave, 'ar' | 'wallets' | 'utils' | 'crypto' | 'transactions'>;
   contract: {
     id: string;
   };
@@ -47,6 +47,7 @@ export class SmartWeaveGlobal {
       utils: arweave.utils,
       wallets: arweave.wallets,
       crypto: arweave.crypto,
+      transactions: arweave.transactions,
     };
     this.contract = contract;
     this.transaction = new Transaction(this);
@@ -102,6 +103,13 @@ class Transaction {
       throw new Error('No current Tx');
     }
     return this.global._activeTx.fee.winston;
+  }
+
+  get parent() {
+    if (!this.global._activeTx) {
+      throw new Error('No current Tx');
+    }
+    return this.global._activeTx.parent.id;
   }
 }
 

--- a/src/smartweave-global.ts
+++ b/src/smartweave-global.ts
@@ -109,7 +109,7 @@ class Transaction {
     if (!this.global._activeTx) {
       throw new Error('No current Tx');
     }
-    return this.global._activeTx.parent.id;
+    return this.global._activeTx.parent && this.global._activeTx.parent.id;
   }
 }
 


### PR DESCRIPTION
Hiya 👋🏻

It would be useful if there was a way to check if a specific interaction transaction is part of an Arweave bundle.

This PR adds:
- `SmartWeave.transaction.parent`
  - `null` if the transaction isn't part of a bundle.
  - A valid Arweave transaction ID if it is part of a bundle.
- `SmartWeave.arweave.transactions`
  - Allows the user to retrieve information about this parent transaction.