### PR TITLE
feat: optionally return interaction validity info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smartweave",
   "version": "0.4.12",
-  "description": "Uses lazy-evaluation to move the burden of contract execution from network nodes to smart contract users.",
+  "description": "Simple, scalable smart contracts on the Arweave protocol.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/src/contract-read.ts
+++ b/src/contract-read.ts
@@ -42,8 +42,7 @@ export async function readContract(arweave: Arweave, contractId: string, height?
 
   const { handler, swGlobal } = contractInfo;
 
-  const validTxs = [];
-  const invalidTxs = [];
+  const valid: Record<string, boolean> = {};
 
   for (const txInfo of txInfos) {
     const tags = formatTags(txInfo.node.tags);
@@ -91,16 +90,12 @@ export async function readContract(arweave: Arweave, contractId: string, height?
       log(arweave, `Executing of interaction: ${currentTx.id} returned error.`);
     }
 
-    if (result.type === 'ok') {
-      validTxs.push(currentTx.id);
-    } else {
-      invalidTxs.push(currentTx.id);
-    }
+    valid[currentTx.id] = result.type === 'ok';
 
     state = result.state;
   }
 
-  return details ? { state, validTxs, invalidTxs } : state;
+  return details ? { state, valid } : state;
 }
 
 // Sort the transactions based on the sort key generated in addSortKey()

--- a/src/contract-read.ts
+++ b/src/contract-read.ts
@@ -10,12 +10,12 @@ import { GQLEdgeInterface } from './interfaces/gqlResult';
  *
  * If height is provided, will replay only to that block height.
  *
- * @param arweave     an Arweave client instance
- * @param contractId  the Transaction Id of the contract
- * @param height      if specified the contract will be replayed only to this block height
- * @param details     if true, the function will return valid and invalid transaction IDs along with the state
+ * @param arweave         an Arweave client instance
+ * @param contractId      the Transaction Id of the contract
+ * @param height          if specified the contract will be replayed only to this block height
+ * @param returnValidity  if true, the function will return valid and invalid transaction IDs along with the state
  */
-export async function readContract(arweave: Arweave, contractId: string, height?: number, details?: boolean): Promise<any> {
+export async function readContract(arweave: Arweave, contractId: string, height?: number, returnValidity?: boolean): Promise<any> {
   if (!height) {
     const networkInfo = await arweave.network.getInfo();
     height = networkInfo.height;
@@ -42,7 +42,7 @@ export async function readContract(arweave: Arweave, contractId: string, height?
 
   const { handler, swGlobal } = contractInfo;
 
-  const valid: Record<string, boolean> = {};
+  const validity: Record<string, boolean> = {};
 
   for (const txInfo of txInfos) {
     const tags = formatTags(txInfo.node.tags);
@@ -90,12 +90,12 @@ export async function readContract(arweave: Arweave, contractId: string, height?
       log(arweave, `Executing of interaction: ${currentTx.id} returned error.`);
     }
 
-    valid[currentTx.id] = result.type === 'ok';
+    validity[currentTx.id] = result.type === 'ok';
 
     state = result.state;
   }
 
-  return details ? { state, valid } : state;
+  return returnValidity ? { state, validity } : state;
 }
 
 // Sort the transactions based on the sort key generated in addSortKey()


### PR DESCRIPTION
This PR adds an *optional* parameter to the `readContract` function.

When the user sets the `returnValidity` parameter to true,
a dictionary containing validity information about interaction transactions is returned, along with the current state.