### PR TITLE
Added unsafeClient access for contracts.

### DIFF
--- a/CONTRACT-GUIDE.md
+++ b/CONTRACT-GUIDE.md
@@ -151,4 +151,6 @@ It provides a method to read another contracts state (this will read the state a
 SmartWeave.contracts.readContractState(contractId: string): Promise<any>
 ```
 
+Finally, it also provides complete access to the full Arweave.js client under `SmartWeave.unsafeClient`. Use of this library in your smart contracts can easily introduce non-determinism, which could cause your contract to have inconsistent state between users. It does, however, have a number of legitimate and safe uses if deployed carefully. You have been warned!
+
 See [examples/read-other-contract.js](examples/read-other-contract.js) for an example of reading another contracts state.

--- a/examples/unsafeclient-example.js
+++ b/examples/unsafeclient-example.js
@@ -1,0 +1,19 @@
+// An example contract that uses the SmartWeave.unsafeClient interface to read a 
+// large amount of data into the smart contract.
+//
+// This mechanism is inherently unsafe if you have no strong guarantee that the
+// transaction in question is well-seeded in the network. If you do know this,
+// however, you can use this system to load large amounts of state into the
+// contract.
+
+export async function handle (state, action) {
+  if (action.input.function === 'loadState') {
+    let txid = action.input.txid
+
+	state = await SmartWeave.unsafeClient.transactions.getData(txid, {decode: true, string: true})
+
+    return { state }
+  }
+
+  throw new ContractError('Invalid input')
+}

--- a/src/smartweave-global.ts
+++ b/src/smartweave-global.ts
@@ -22,6 +22,9 @@ import { readContract } from './contract-read';
  * - SmartWeave.arweave.wallets
  * - SmartWeave.arweave.ar
  *
+ * as well as access to the potentially non-deterministic full client:
+ * - SmartWeave.unsafeClient
+ *
  */
 export class SmartWeaveGlobal {
   transaction: Transaction;
@@ -30,6 +33,7 @@ export class SmartWeaveGlobal {
   contract: {
     id: string;
   };
+  unsafeClient: Arweave;
 
   contracts: {
     readContractState: (contractId: string) => Promise<any>;
@@ -42,11 +46,12 @@ export class SmartWeaveGlobal {
   }
 
   constructor(arweave: Arweave, contract: { id: string }) {
+	this.unsafeClient = arweave;
     this.arweave = {
       ar: arweave.ar,
       utils: arweave.utils,
       wallets: arweave.wallets,
-      crypto: arweave.crypto,
+      crypto: arweave.crypto
     };
     this.contract = contract;
     this.transaction = new Transaction(this);


### PR DESCRIPTION
This PR allows access to the full Arweave.js client library inside a SmartWeave contract context. This operation is powerful, but dangerous. It allows, for example, the loading of Arweave TX data into a smart contract for processing (if the developer has a strong guarantee that the TX is sufficiently seeded).

The dangers of using the `unsafeClient` are documented as part of this PR, and implied by its name.