### PR TITLE
Updated utils.js

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export function getTag(tx: Transaction, name: string) {
  * @param tx
  */
 export function unpackTags(tx: Transaction): Record<string, string | string[]> {
-  const tags = tx.get('tags') as any;
+  const tags = tx['tags'] as any;
   const result: Record<string, string | string[]> = {};
 
   for (const tag of tags) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ interface UnformattedTag {
 }
 
 export function getTag(tx: Transaction, name: string) {
-  const tags = tx.get('tags') as any;
+  const tags = tx['tags'] as any;
 
   for (const tag of tags) {
     // decoding tags can throw on invalid utf8 data.


### PR DESCRIPTION
Changes tx.get(id) to tx[id] to support prediction of passed signed transaction which doesn't contain the get function