### PR TITLE
fix: lexographical sorting

### DIFF
--- a/src/contract-read.ts
+++ b/src/contract-read.ts
@@ -145,7 +145,10 @@ async function addSortKey(arweave: Arweave, txInfo: any) {
   const txIdBytes = arweave.utils.b64UrlToBuffer(node.id);
   const concatted = arweave.utils.concatBuffers([blockHashBytes, txIdBytes]);
   const hashed = arrayToHex(await arweave.crypto.hash(concatted));
-  const blockHeight = `000000${node.block.height}`.slice(-12);
+  // Note for the future:
+  // If Arweave ever surpasses a 12 digit block height,
+  // all contracts will be broken.
+  const blockHeight = `${node.block.height}`.padStart(12, '0');
 
   txInfo.sortKey = `${blockHeight},${hashed}`;
 }

--- a/src/contract-read.ts
+++ b/src/contract-read.ts
@@ -52,7 +52,10 @@ export async function readContract(
 
   log(arweave, `Replaying ${txInfos.length} confirmed interactions`);
 
-  await sortTransactions(arweave, txInfos);
+  txInfos.sort(
+    (a: { node: InteractionTx }, b: { node: InteractionTx }) =>
+      a.node.block.height - b.node.block.height || a.node.id.localeCompare(b.node.id),
+  );
 
   let { handler, swGlobal } = contractInfo;
 
@@ -124,33 +127,6 @@ export async function readContract(
   }
 
   return returnValidity ? { state, validity } : state;
-}
-
-// Sort the transactions based on the sort key generated in addSortKey()
-async function sortTransactions(arweave: Arweave, txInfos: any[]) {
-  const addKeysFuncs = txInfos.map((tx) => addSortKey(arweave, tx));
-  await Promise.all(addKeysFuncs);
-
-  txInfos.sort((a, b) => a.sortKey.localeCompare(b.sortKey));
-}
-
-// Construct a string that will lexographically sort.
-// { block_height, sha256(block_indep_hash + txid) }
-// pad block height to 12 digits and convert hash value
-// to a hex string.
-async function addSortKey(arweave: Arweave, txInfo: any) {
-  const { node } = txInfo;
-
-  const blockHashBytes = arweave.utils.b64UrlToBuffer(node.block.id);
-  const txIdBytes = arweave.utils.b64UrlToBuffer(node.id);
-  const concatted = arweave.utils.concatBuffers([blockHashBytes, txIdBytes]);
-  const hashed = arrayToHex(await arweave.crypto.hash(concatted));
-  // Note for the future:
-  // If Arweave ever surpasses a 12 digit block height,
-  // all contracts will be broken.
-  const blockHeight = `${node.block.height}`.padStart(12, '0');
-
-  txInfo.sortKey = `${blockHeight},${hashed}`;
 }
 
 // the maximum number of transactions we can get from graphql at once


### PR DESCRIPTION
Hey everyone 👋🏻

We ran into the following issue when testing the @KYVENetwork contracts using [ArLocal](https://github.com/textury/arlocal).

Say we have two contract interactions at block heights 5 and 10. The old implementation would return the following:

```js
"000000500000,<HASH>" // block height 5
"000000100000,<HASH>" // block height 10
```

As you can see, JavaScript would sort block height 5 after block height 10.
This resulted in incorrect state computations.

The only reason why this hasn't occurred in production yet is that SmartWeave was introduced after Arweave was in six-digit block heights. However, in around 300,000 blocks, this will change for the worse.

Let's take the current block height as of writing this: 714,515.
As well as the first seven-digit block height: 1,000,000.

```js
"000000714515,<HASH>" // block height 714,515
"000000100000,<HASH>" // block height 1,000,000 (last zero gets removed due to .slice)
```

As you can see, a seven-digit block happened before a six-digit block?!

This fix pads instead of slices the block heights so that they are correctly sorted.
However, this will eventually not work when Arweave has thirteen-digit block heights.