### PR TITLE
fix: ownerToAddress

### DIFF
--- a/examples/test-api-things.js
+++ b/examples/test-api-things.js
@@ -15,8 +15,7 @@ export async function handle (state, input) {
     SmartWeave.arweave.utils.bufferToB64Url(
       await SmartWeave.arweave.utils.crypto.hash(ownerBytes)
     )
-  const from2 = SmartWeave.utils.wallets.ownerToAddress(txOwner)
 
-  state.log = [...state.log, { blockHeight, blockIndepHash, txId, txOwner: txOwner, txTarget, txQuantity, txReward, txTags, from, from2, contractId }]
+  state.log = [...state.log, { blockHeight, blockIndepHash, txId, txOwner: txOwner, txTarget, txQuantity, txReward, txTags, from, contractId }]
   return { state }
 }


### PR DESCRIPTION
Seems like   `SmartWeave.utils.wallets.ownerToAddress()` throws an error in a SWC. The working alternative is to use the `unsafe` client: `SmartWeave.unsafeClient.wallets.ownerToAddress()` .

Just fixed the examples to reduce the unexpected errors for those who follow the examples while learning about SmartWeave features.