### PR TITLE
fix: fix the failing test by using newer arlocal version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@textury/arlocal": "^1.0.12",
+    "@textury/arlocal": "^1.0.14",
     "@types/jest": "^26.0.23",
     "@types/node": "^14.14.28",
     "@types/yargs": "^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,10 +649,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@textury/arlocal@^1.0.12":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@textury/arlocal/-/arlocal-1.0.12.tgz#adf84f4ebf4c809b624e6554c61cb74cc42a2872"
-  integrity sha512-SjUUQWxs1oYbHdidHIuP2aRfyrqObeOyq9PNKdcz6xdKuLSb6yG0GeYB6VSal2LXSd+4n7UUcqop+ab1qN12cw==
+"@textury/arlocal@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@textury/arlocal/-/arlocal-1.0.14.tgz#a09b215b27f53afaeec0cb00986d8008827db3a5"
+  integrity sha512-yezq9qnB0M5qhhQ3zHK6ug/k8fXAtVHSUyvEiVPh3V3UNrEgGf/Dg73kmSnhxhrqzws7DrGck0lA+zsvS/pY5w==
   dependencies:
     "@koa/cors" "^3.1.0"
     apollo-server-koa "^2.25.1"


### PR DESCRIPTION
Current error when running `yarn test`

```
yarn test
yarn run v1.22.10
$ jest
 PASS  src/__tests__/utils.spec.ts
(node:62127) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
 FAIL  src/__tests__/evolve.spec.ts
  ● Testing the evolve feature › evolve any contract

    ENOENT: no such file or directory, stat '/Users/hlodversigurdsson/arweave/SmartWeave/node_modules/@textury/arlocal/bin/.db'

      at ArLocal.<anonymous> (node_modules/@textury/arlocal/src/app.ts:107:5)
      at node_modules/@textury/arlocal/bin/app.js:8:71
      at Object.<anonymous>.__awaiter (node_modules/@textury/arlocal/bin/app.js:4:12)
      at ArLocal.startDB (node_modules/@textury/arlocal/bin/app.js:87:16)
      at ArLocal.<anonymous> (node_modules/@textury/arlocal/src/app.ts:71:16)


  ● Test suite failed to run

    TypeError: Cannot read property 'close' of undefined

      59 |
      60 |   afterAll(async () => {
    > 61 |     await arlocal.stop();
         |                   ^
      62 |   });
      63 |
      64 |   test('evolve any contract', async () => {

      at ArLocal.<anonymous> (node_modules/@textury/arlocal/src/app.ts:125:17)
      at node_modules/@textury/arlocal/bin/app.js:8:71
      at Object.<anonymous>.__awaiter (node_modules/@textury/arlocal/bin/app.js:4:12)
      at ArLocal.stop (node_modules/@textury/arlocal/bin/app.js:101:16)
      at src/__tests__/evolve.spec.ts:61:19
      at src/__tests__/evolve.spec.ts:8:71

Test Suites: 1 failed, 1 passed, 2 total
Tests:       1 failed, 2 passed, 3 total
Snapshots:   0 total
Time:        2.385 s
Ran all test suites.
error Command failed with exit code 1.
```