### PR TITLE
Allow to pass custom readContract function

### DIFF
--- a/src/contract-load.ts
+++ b/src/contract-load.ts
@@ -63,12 +63,11 @@ export function createContractExecutionEnvironment(
   contractSrc: string,
   contractId: string,
   contractOwner: string,
+  customReadContract?: any,
 ) {
   const returningSrc = normalizeContractSource(contractSrc);
-  const swGlobal = new SmartWeaveGlobal(arweave, { id: contractId, owner: contractOwner });
+  const swGlobal = new SmartWeaveGlobal(arweave, { id: contractId, owner: contractOwner, customReadContract });
   const getContractFunction = new Function(returningSrc); // eslint-disable-line
-
-  // console.log(returningSrc);
 
   return {
     handler: getContractFunction(swGlobal, BigNumber, clarity) as ContractHandler,

--- a/src/contract-step.ts
+++ b/src/contract-step.ts
@@ -45,7 +45,6 @@ export interface ContractInteractionResult {
  * @param contractSrc   the source code of the contract
  * @param input         the input interaction, should be a plain Js object
  * @param state         the current state of the contract
- * @param caller        the wallet address of the caller who is interacting with the contract
  */
 export async function execute(
   handler: ContractHandler,

--- a/src/smartweave-global.ts
+++ b/src/smartweave-global.ts
@@ -46,7 +46,14 @@ export class SmartWeaveGlobal {
     return !this._activeTx;
   }
 
-  constructor(arweave: Arweave, contract: { id: string; owner: string }) {
+  constructor(
+    arweave: Arweave,
+    contract: {
+      id: string;
+      owner: string;
+      customReadContract: (arweave: Arweave, contractId: string, height?: number, returnValidity?: boolean) => any;
+    },
+  ) {
     this.unsafeClient = arweave;
     this.arweave = {
       ar: arweave.ar,
@@ -57,9 +64,12 @@ export class SmartWeaveGlobal {
     this.contract = contract;
     this.transaction = new Transaction(this);
     this.block = new Block(this);
+
+    const readContractFn = contract.customReadContract || readContract;
+
     this.contracts = {
       readContractState: (contractId: string, height?: number, returnValidity?: boolean) =>
-        readContract(
+        readContractFn(
           arweave,
           contractId,
           height || (this._isDryRunning ? Number.POSITIVE_INFINITY : this.block.height),


### PR DESCRIPTION
Permits us to have more control over the kind of potentially heavy asynchronous work done during contract state computation.

Also minor comment change on something that seems to have been forgotten.